### PR TITLE
Añadir footer con informacion del Autor.

### DIFF
--- a/theme/templates/about_author.html
+++ b/theme/templates/about_author.html
@@ -1,0 +1,11 @@
+<hr>    
+<div class="row">
+  <div class="col-md-2">
+    <img src={{ author_avatar }} alt="photo" class="img-author img-rounded"/>
+  </div>
+  <div class="col-md-1"></div>
+  <div class="col-md-9 description-author">
+    <p>{{ author_description }}</p>
+  </div>
+</div> 
+

--- a/theme/templates/article.html
+++ b/theme/templates/article.html
@@ -29,8 +29,12 @@
                 {% endfor %}
             </div>
         </div>
-    </article>
 
+        {% for author in article.authors %}
+          {% include author.url  ignore missing %}
+        {% endfor %}
+
+    </article>
   {% include '_includes/isso_thread.html' %}
 
 </div>

--- a/theme/templates/author/manuel-garrido.html
+++ b/theme/templates/author/manuel-garrido.html
@@ -1,0 +1,5 @@
+{% set author_avatar = 'https://media.licdn.com/mpr/mpr/shrinknp_400_400/AAEAAQAAAAAAAAJ_AAAAJDQ1MzNjMDFkLWI1ZmQtNGFjYy1iYWY1LWMxNjMxNDg4M2U3OA.jpg' %}  
+{% set author_description = """Manuel ha estado 4 años en Nueva York, primero trabajando como Senior Analyst para la NBC y luego como Data Scientist. Tras trabajar en varias empresas, ahora trabaja como Data Scientist Consultant, tanto para clientes españoles como extranjeros. Si necesitas ayuda, no dudes en contactarle!
+""" %}
+{% set author_twitter = 'https://twitter.com/manugarri' %}
+{% include 'about_author.html' %}

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -78,15 +78,15 @@
         {% block content %}{% endblock %}
         </div>
 
-        <div class="container-fluid">
-          <footer class="disclaimer">
+        <footer class="disclaimer">
+          <div class="container-fluid">
             <p>
               © 2012-2017 {{ AUTHOR  }}, licencia <a href="{{ LICENSE_URL }}"> {{ LICENSE_NAME }}</a>
               salvo otra indicación.
               <p>Contenido generado con <a href= "http://docs.getpelican.com/">Pelican</a>.</p>
             </p>
-          </footer>
-        </div>
+          </div>
+        </footer>
 
         {% include '_includes/analytics.html' %}
     </body>

--- a/theme/templates/main.less
+++ b/theme/templates/main.less
@@ -4,6 +4,17 @@
 @link-color: #007EE5;
 @read-more-color: #007AA3;
 
+
+.description-author {
+    font-size: 0.8em;
+    color: #333;
+}
+
+.img-author {
+    max-height: 10em;
+    max-width: 10em;
+}
+
 body {
     margin: 0;
     padding: 0;
@@ -354,4 +365,9 @@ article {
 
 .disclaimer {
     text-align: center;
+    background-color: #EFEFEF;
+    border-bottom: none;
+    margin-top: 6em;
 }
+
+


### PR DESCRIPTION
Relacionada https://github.com/Pybonacci/pybonacci.github.io-source/issues/2

He añadido el soporte para un footer con informacion de los autores del articulo.

Para añadir un autor, simplemente hay que añadir un archivo `author-slug.html` (con el slug del autor) en `theme/templates/author`. Como ejemplo pongo el mio aqui 

```
{% set author_avatar = 'https://media.licdn.com/mpr/mpr/shrinknp_400_400/AAEAAQAAAAAAAAJ_AAAAJDQ1MzNjMDFkLWI1ZmQtNGFjYy1iYWY1LWMxNjMxNDg4M2U3OA.jpg' %}  
{% set author_description = """Manuel ha estado 4 años en Nueva York, primero trabajando como Senior Analyst para la NBC y luego como Data Scientist. Tras trabajar en varias empresas, ahora trabaja como Data Scientist Consultant, tanto para clientes españoles como extranjeros. Si necesitas ayuda, no dudes en contactarle!
""" %}
{% set author_twitter = 'https://twitter.com/manugarri' %}
{% include 'about_author.html' %}
```

Basicamente hago un set de las variables `author_description y `author_avatar` y luego incluyo el template `about_author.html` que las referencia. Pongo en mi ejemplo `author_twitter` como ejemplo de que esta implementacion permite añadir cualquier tipo de información que se puede inyectar en la plantilla.

Aqui pongo una captura del aspecto del footer.

![foo](https://i.imgur.com/jCFJZ50.png)

Además, he añadido el cambio a base.html y el css de #26 , por algún motivo no lo habia comiteado.